### PR TITLE
Export memory flows as python file

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ loader = Loader('/path/to/file/flow.yaml')
 jobs = loader.as_job_objects()
 ```
 
+### Dump memory flows to a Python File (just for V2)
+
+```python
+from auror_core.v2.dumper import Dumper
+
+com1 = Job() \
+.with_name("commands job 1") \
+.with_(command="bash echo 1")
+
+com2 = Job()\
+.with_name("commands job 2")\
+.with_(command="bash echo 2")
+
+dumper = Dumper('/path/to/desired/directory') # will be dumped with 'flow.py' name
+dumper.dump_jobs(com1, com2)
+```
+
 ## Plugins
 
 Plugins are just extensions from auror_core

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install auror_core
 * [Using Flow Environment Variables and Params](#using-flow-environment-variables-and-params)
 * [Join multiple variables in one](#join-multiple-variables-in-one)
 * [Load jobs from YAML File (just for V2)](#Load-jobs-from-yaml-file-(just-for-v2))
+* [Dump memory flows to a Python File (just for V2)](#dump-memory-flows-to-a-python-file-(just-for-v2))
 
 
 ### Creating a simple Azkaban flow with one command 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,15 @@ loader = Loader('/path/to/file/flow.yaml')
 jobs = loader.as_job_objects()
 ```
 
+Or you can export these jobs as a Python File
+
+```python
+from auror_core.v2.loader import Loader
+
+loader = Loader('/path/to/file/flow.yaml')
+jobs = loader.as_python_file('/path/to/desired/directory') # will be dumped with 'flow.py' name
+```
+
 ### Dump memory flows to a Python File (just for V2)
 
 ```python

--- a/auror_core/v2/dumper.py
+++ b/auror_core/v2/dumper.py
@@ -1,0 +1,29 @@
+import os
+
+import autopep8
+
+
+class Dumper:
+    
+    DEFAULT_IMPORTS = 'from auror_core.v2.job import Command\n\n\n'
+
+    def __init__(self, path):
+        if not os.path.exists(path):
+            raise ValueError('Directory, {}, does not exist'.format(path))
+        self.path = path
+
+    def dump_jobs(self, *jobs):
+        _path = f'{self.path}/flow.py'
+        with open(_path, 'w') as _file:
+            _file.write(self.DEFAULT_IMPORTS)
+            for job_number, job in enumerate(jobs):
+                _file.write('job_{} = {}\n\n'.format(job_number, repr(job)))
+        self.__format_file(_path)
+
+    def __format_file(self, path):
+        autopep8.fix_file(
+            path,
+            options=autopep8.parse_args(
+                ['--in-place', '--aggressive', path]
+            )
+        )

--- a/auror_core/v2/dumper.py
+++ b/auror_core/v2/dumper.py
@@ -13,7 +13,7 @@ class Dumper:
         self.path = path
 
     def dump_jobs(self, *jobs):
-        _path = f'{self.path}/flow.py'
+        _path = '{}/flow.py'.format(self.path)
         with open(_path, 'w') as _file:
             _file.write(self.DEFAULT_IMPORTS)
             for job_number, job in enumerate(jobs):

--- a/auror_core/v2/job.py
+++ b/auror_core/v2/job.py
@@ -25,6 +25,16 @@ class Job(object):
             self.nodes == other.nodes and \
             self.extra == other.extra and \
             self.properties == other.properties
+    
+    def __repr__(self):
+        return "{}(name='{}', config={}, dependencies={}, nodes={}, extra={})".format(
+            type(self).__name__,
+            self.name,
+            self.config,
+            self.dependencies,
+            self.nodes,
+            self.extra,
+        )
 
     def instance(self, name, config, dependencies, nodes, extra):
         return self.__class__(name, config, dependencies, nodes, extra)

--- a/auror_core/v2/loader.py
+++ b/auror_core/v2/loader.py
@@ -1,9 +1,9 @@
 import os
-import copy
 
 import yaml
 
 from auror_core.v2.job import Job
+from auror_core.v2.dumper import Dumper
 from auror_core.v2 import JobType
 
 
@@ -30,5 +30,6 @@ class Loader:
             job['nodes'] = self.__as_job_objects(job.get('nodes'))
         return JobType.get_job_type_class(job.get('type')).build(job)
 
-    def as_python_file(self):
-        raise NotImplementedError('"as_python_file" method is not implemented yet')
+    def as_python_file(self, directory):
+        dumper = Dumper(directory)
+        dumper.dump_jobs(*self.as_job_objects())

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     license='MIT',
     install_requires=[
         "javaproperties==0.5.1",
-        "pyaml==18.11.0"
+        "pyaml==18.11.0",
+        "autopep8==1.4.4",
     ],
     extras_require={
         "test": ["mock",]

--- a/tests/unit/v2/test_dumper.py
+++ b/tests/unit/v2/test_dumper.py
@@ -1,0 +1,122 @@
+import shutil
+import tempfile
+
+import autopep8
+
+from unittest import TestCase
+
+from auror_core.v2.job import Command
+from auror_core.v2.dumper import Dumper
+
+
+class TestDumper(TestCase):
+    
+    def setUp(self):
+        self.tem_dir = tempfile.mkdtemp()
+        self.dumper = Dumper(self.tem_dir)
+    
+    def tearDown(self):
+        shutil.rmtree(self.tem_dir)
+    
+    def test_should_raise_an_exception_on_inexistence_directory(self):
+        path = '/this/path/does/not/exist'
+        with self.assertRaises(ValueError) as context:
+            Dumper(path)
+        self.assertTrue(
+            'Directory, {}, does not exist'.format(path) in str(context.exception)
+        )
+    
+    def test_dump_simple_job(self):
+        simple_job = Command(
+            name='shell_pwd',
+            config={
+                'command': 'pwd'
+            }
+        )
+        expected_file_content = autopep8.fix_code(
+            '{}job_0 = {}\n'.format(Dumper.DEFAULT_IMPORTS, repr(simple_job)),
+            options={
+                'aggressive': True,
+            }
+        )
+
+        self.dumper.dump_jobs(simple_job)
+
+        with open('{}/flow.py'.format(self.tem_dir)) as _file:
+            file_content = ''.join(_file.readlines())
+        self.assertEqual(expected_file_content, file_content)
+    
+    def test_dump_two_jobs(self):
+        job = Command(
+            name='shell_pwd',
+            config={
+                'command': 'pwd'
+            }
+        )
+        expected_file_content = autopep8.fix_code(
+            '{}job_0 = {}\n\njob_1 = {}\n'.format(Dumper.DEFAULT_IMPORTS, repr(job), repr(job)),
+            options={
+                'aggressive': True,
+            }
+        )
+
+        self.dumper.dump_jobs(job, job)
+        
+        with open('{}/flow.py'.format(self.tem_dir)) as _file:
+            file_content = ''.join(_file.readlines())
+        self.assertEqual(expected_file_content, file_content)
+    
+    def test_dump_embbed_job(self):
+        internal_job = Command(
+            name='shell_pwd',
+            config={
+                'command': 'pwd'
+            }
+        )
+        embbed_job = Command(
+            name='embedded_flow1',
+            config={
+                'command': 'flow_command',
+            },
+            nodes=[internal_job,]
+        )
+
+        expected_file_content = autopep8.fix_code(
+            '{}job_0 = {}\n'.format(Dumper.DEFAULT_IMPORTS, repr(embbed_job)),
+            options={
+                'aggressive': True,
+            }
+        )
+
+        self.dumper.dump_jobs(embbed_job)
+        
+        with open('{}/flow.py'.format(self.tem_dir)) as _file:
+            file_content = ''.join(_file.readlines())
+        self.assertEqual(expected_file_content, file_content)
+    
+    def test_dump_one_embbed_job_and_one_simple_job(self):
+        job = Command(
+            name='shell_pwd',
+            config={
+                'command': 'pwd'
+            }
+        )
+        embbed_job = Command(
+            name='embedded_flow1',
+            config={
+                'command': 'flow_command',
+            },
+            nodes=[job,]
+        )
+        expected_file_content = autopep8.fix_code(
+            '{}job_0 = {}\n\njob_1 = {}\n'.format(Dumper.DEFAULT_IMPORTS, repr(job), repr(embbed_job)),
+            options={
+                'aggressive': True,
+            }
+        )
+
+        self.dumper.dump_jobs(job, embbed_job)
+        
+        with open('{}/flow.py'.format(self.tem_dir)) as _file:
+            file_content = ''.join(_file.readlines())
+        self.assertEqual(expected_file_content, file_content)


### PR DESCRIPTION
A class named `Dumper` was created to dump the jobs to a Python File, to make this, the Job class and subclasses is responsible for give its representation implementing the dunder method `__repr__`.
The required method was implemented in 'Job' class and its subclasses inherited this implementation, so far, it's enough.

To format the dumped file I chose the lib `autopep8` instead [black](https://github.com/psf/black) or [yapf](https://github.com/google/yapf), because it gives support to Python 2.7 & 3.4+ and `auror_core` offers support to the same versions.

closes #8 