### PR TITLE
Initial documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'auror_core'
+copyright = '2019, globocom'
+author = 'globocom'
+
+# The full version, including alpha/beta/rc tags
+release = '1.2.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,55 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+Auror Core documentation!
+======================================
+
+A simple library to create dynamically flows on Azkaban.
+
+.. image:: https://pm1.narvii.com/6278/52c20397d131f309c687f0baa5125968cf79aea3_hq.jpg
+
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install auror_core
+
+
+Supported Job Types
+-------------------
+
+V1
+''
+    - Command
+    - Flow
+
+V2
+''
+    - Command
+
+
+Content
+-------
+.. toctree::
+   :maxdepth: 3
+
+   usage
+   plugins
+
+
+Contribute
+----------
+
+For development and contributing, please follow `Contributing Guide`__ and ALWAYS respect the `Code of Conduct`__
+
+.. __: https://github.com/globocom/auror-core/blob/master/CONTRIBUTING.md
+.. __: https://github.com/globocom/auror-core/blob/master/CODE_OF_CONDUCT.md

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,19 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+
+Plugins
+=============
+
+Plugins are just extensions from auror_core
+
+There is a cookiecutter for new azkaban jobtypes with Auror template too: https://github.com/globocom/azkaban-jobtype-cookiecutter
+
+We already have email plugin: https://github.com/globocom/azkaban-jobtype-email

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,292 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+
+Usage
+=============
+
+V1
+--
+
+
+Simple Azkaban flow
+'''''''''''''''''''
+
+You just need to import job type and project
+
+.. code:: python
+
+    from auror_core.v1.job import Job, Command
+    from auror_core import Project
+
+    com1 = Job()\
+        .as_type(Command)\
+        .with_name("commands job")\
+        .with_command("bash echo 1")\
+        .with_another_command("bash echo 2")
+
+    Project("folder_to_generate_files", com1).write()
+
+
+Job with extra customization and configuration
+''''''''''''''''''''''''''''''''''''''''''''''
+
+Simulating a Command with base Job (NOT RECOMMENDED)
+
+.. code:: python
+
+    from auror_core.v1.job import Job
+    from auror_core import Project
+
+    com1 = Job()\
+        .with_name("commands job")\
+        .with_(command="bash echo 1")
+
+    com1._type = "command"
+
+    Project("folder_to_generate_files", com1).write()
+
+
+Integrating with Flow
+'''''''''''''''''''''
+
+V2 already have flow included
+
+.. code:: python
+
+    from auror_core.v1.job import Command, Flow, Job
+    from auror_core import Project
+
+    com1 = Command() \
+        .with_name("commands job") \
+        .with_command("bash echo 1")
+
+    flow = Job() \
+        .as_type(Flow) \
+        .with_name("flow") \
+        .with_dependencies(com1)
+
+    Project("folder_to_generate_files", com1, flow).write()
+
+
+V2
+--
+
+
+Simple V2 Azkaban flow
+''''''''''''''''''''''
+
+V2 flow is implemented under v2 subfolder with same job types
+
+.. code:: python
+
+    from auror_core.v2.job import Job, Command
+    from auror_core import Project
+
+    com1 = Job() \
+        .as_type(Command) \
+        .with_name("commands job") \
+        .with_command("bash echo 1") \
+        .with_another_command("bash echo 2")
+
+    Project("folder_to_generate_files", com1).is_v2().write()
+
+
+Flows with dependencies
+'''''''''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.job import Job, Command
+    from auror_core import Project
+
+    com1 = Job() \
+        .as_type(Command) \
+        .with_name("commands job") \
+        .with_command("bash echo 1") \
+        .with_another_command("bash echo 2")
+
+    com2 = Command() \
+        .with_name("sub command job") \
+        .with_command("bash echo 1") \
+        .with_dependencies(com1)
+
+    Project("folder_to_generate_files", com1, com2).is_v2().write()
+
+
+Sharing job attributes
+''''''''''''''''''''''
+
+Organize jobs with same configuration
+
+.. code:: python
+
+    from auror_core.v2.job import Command
+    from auror_core import Project
+
+    com = Command() \
+        .with_command("bash echo 1")
+
+    com1 = com.with_name("commands job") \
+        .with_another_command("bash echo 2")
+
+    com2 = com.with_name("sub command job") \
+        .with_dependencies(com1)
+
+    Project("folder_to_generate_files", com1, com2).is_v2().write()
+
+
+Using Flow Params
+'''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.job import Command
+    from auror_core.v2.params import Params
+    from auror_core import Project
+
+    params = Params(
+        teste1="my test",
+        variable="my variable"
+    )
+
+    com = Command() \
+        .with_command("bash echo ${variable}")
+
+    Project("folder_to_generate_files", com) \
+        .is_v2() \
+        .with_params(params) \
+        .write()
+
+
+Using Flow Environment Variables
+''''''''''''''''''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.job import Command
+    from auror_core.v2.params import Env
+    from auror_core import Project
+
+    env = Env(
+        TESTE="my test",
+        VARIABLE="my variable"
+    )
+
+    com = Command() \
+        .with_command("bash echo $VARIABLE")
+
+    Project("folder_to_generate_files", com) \
+        .is_v2() \
+        .with_params(env) \
+        .write()
+
+
+Using Flow Environment Variables and Params
+'''''''''''''''''''''''''''''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.job import Command
+    from auror_core.v2.params import Env, Params
+    from auror_core import Project
+
+    env = Env(
+        TESTE="my test",
+        VARIABLE="my variable"
+    )
+
+    params = Params(
+        teste1="my test",
+        variable="my variable"
+    )
+
+    com = Command() \
+        .with_command("bash echo $VARIABLE ${variable}")
+
+    Project("folder_to_generate_files", com) \
+        .is_v2() \
+        .with_params(params, env) \
+        .write()
+
+
+Join multiple variables in one
+''''''''''''''''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.job import Command
+    from auror_core.v2.params import Env
+    from auror_core import Project
+
+    env = Env(
+        TESTE="env test",
+        VARIABLE="env variable"
+    )
+
+    params = Params(
+        teste1="my test",
+        variable="my variable"
+    )
+
+    one_param = ParamsJoin("params_strange_name", ",") ## param name and separator
+
+    com = Command() \
+        .with_command("bash echo ${params_strange_name}") 
+    ## it will print: my test,my variable,env test,env variable
+    ## THERE IS NO ORDER GUARANTEE, JUST Python 3.6 >
+
+    Project("folder_to_generate_files", com) \
+        .is_v2() \
+        .with_params(one_param(params, env)) \
+        .write()
+
+
+Load jobs from YAML File
+''''''''''''''''''''''''
+
+You can find some YAML File examples on `Azkaban Flow Documentation`__
+
+.. __: https://github.com/azkaban/azkaban/wiki/Azkaban-Flow-2.0-Design#flow-yaml-file
+
+.. code:: python
+
+    from auror_core.v2.loader import Loader
+
+    loader = Loader('/path/to/file/flow.yaml')
+    jobs = loader.as_job_objects()
+
+Or you can export these jobs as a Python File
+
+.. code:: python
+
+    from auror_core.v2.loader import Loader
+
+    loader = Loader('/path/to/file/flow.yaml')
+    jobs = loader.as_python_file('/path/to/desired/directory') # will be dumped with 'flow.py' name
+
+
+Dump memory flows to a Python File
+''''''''''''''''''''''''''''''''''
+
+.. code:: python
+
+    from auror_core.v2.dumper import Dumper
+
+    com1 = Job() \
+        .with_name("commands job 1") \
+        .with_(command="bash echo 1")
+
+    com2 = Job() \
+        .with_name("commands job 2") \
+        .with_(command="bash echo 2")
+
+    dumper = Dumper('/path/to/desired/directory') # will be dumped with 'flow.py' name
+    dumper.dump_jobs(com1, com2)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
         "autopep8==1.4.4",
     ],
     extras_require={
-        "test": ["mock","twine"]
+        "test": ["mock","twine"],
+        "docs": ["Sphinx"],
     },
     packages=find_packages(),
 )


### PR DESCRIPTION
I wrote the same documentation that is in README file to some rst files, using [Sphinx](http://www.sphinx-doc.org/en/master/).
You can see the results in the images bellow:

![image](https://user-images.githubusercontent.com/25423500/69775909-1f2d5100-1179-11ea-9123-79a2fd8b0dce.png)

![image](https://user-images.githubusercontent.com/25423500/69776261-41739e80-117a-11ea-896f-73ce4662db3e.png)

**Why Sphinx?**
Because [ReadTheDocs](https://docs.readthedocs.io/en/stable/index.html) has integration with it, you can see the integration in this [link](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html).

I didn't create the page on ReadTheDocs because I think the right way is you (Globo) create an account on it, and adds the documentation there. The tutorial to add is in the link above.

If you want to try the documentation just make the following steps:
```bash
cd docs
make html
```
After the commands, the index page will be available in `build/html/index.html`, just open it.

Validate the structure, please.

closes #6 